### PR TITLE
Meta data was not being brought from other fixtures

### DIFF
--- a/lib/ecto/fixtures/conditioners/associations.ex
+++ b/lib/ecto/fixtures/conditioners/associations.ex
@@ -60,15 +60,23 @@ defmodule EctoFixtures.Conditioners.Associations do
     other_source_atom = String.to_atom(other_source)
     [source, _table_name, :rows, _row_name] = path
 
-    other_row_data = EctoFixtures.read(other_source)
+    other_source_data = EctoFixtures.read(other_source)
     |> EctoFixtures.parse
     |> EctoFixtures.Conditioner.process(source: source)
-    |> get_in([other_source_atom, other_table_name, :rows, other_row_name])
 
-    other_data =
-      %{}
-      |> put_in([other_source_atom], [])
-      |> put_in([other_source_atom, other_table_name], %{rows: [{other_row_name, other_row_data}]})
+    other_source_info = get_in(other_source_data, [other_source_atom, other_table_name])
+
+    other_data = %{
+      other_source_atom => %{
+        other_table_name => %{
+          model: get_in(other_source_data, [other_source_atom, other_table_name, :model]),
+          repo: get_in(other_source_data, [other_source_atom, other_table_name, :repo]),
+          rows: %{
+            other_row_name => get_in(other_source_data, [other_source_atom, other_table_name, :rows, other_row_name])
+          }
+        }
+      }
+    }
 
     { EctoFixtures.Utils.deep_merge(data, other_data),
       [other_source_atom, other_table_name, :rows, other_row_name] }

--- a/test/conditioners/associations_test.exs
+++ b/test/conditioners/associations_test.exs
@@ -29,6 +29,9 @@ defmodule EctoFixtures.Conditioners.AssociationsTest do
 
     assert is_integer(data[other_path][:pets][:rows][:boomer][:data][:owner_id])
     refute Map.has_key?(data[path][:owners][:rows][:brian][:data], :pet)
+
+    assert data[other_path][:pets][:model] == Pet
+    assert data[other_path][:pets][:repo] == Base
   end
 
   test "sets foreign key for belongs_to association properly and removes association" do
@@ -62,6 +65,9 @@ defmodule EctoFixtures.Conditioners.AssociationsTest do
     assert is_integer(data[path][:pets][:rows][:boomer][:data][:owner_id])
     refute Map.has_key?(data[path][:pets][:rows][:boomer][:data], :owner)
     assert data[other_path][:owners][:rows][:brian][:data][:name] == "Brian"
+
+    assert data[other_path][:owners][:model] == Owner
+    assert data[other_path][:owners][:repo] == Base
   end
 
   test "sets foreign key for has_many association properly and removes association" do
@@ -100,5 +106,8 @@ defmodule EctoFixtures.Conditioners.AssociationsTest do
     assert is_integer(data[other_path][:cars][:rows][:nissan][:data][:owner_id])
     assert is_integer(data[other_path][:cars][:rows][:tesla][:data][:owner_id])
     refute Map.has_key?(data[path][:owners][:rows][:brian][:data], :cars)
+
+    assert data[other_path][:cars][:model] == Car
+    assert data[other_path][:cars][:repo] == Base
   end
 end


### PR DESCRIPTION
Fixes bug where the `repo` and `model` meta data was not being merged
into the primary payload object from other fixture files
