### PR TITLE
Cannot use code in fixture definitions with Elixir 1.2

### DIFF
--- a/lib/ecto/fixtures/parser.ex
+++ b/lib/ecto/fixtures/parser.ex
@@ -59,6 +59,7 @@ defmodule EctoFixtures.Parser do
 
   defp parse_columns([]), do: %{}
   defp parse_columns([{field, _, [value]}|tail]) do
+    {value, _} = value |> Code.eval_quoted
     Map.put(%{}, field, value)
     |> Map.merge(parse_columns(tail))
   end

--- a/test/fixtures/single_table_single_row_multiple_columns.exs
+++ b/test/fixtures/single_table_single_row_multiple_columns.exs
@@ -2,5 +2,6 @@ owners model: Owner, repo: Base do
   brian do
     name "Brian"
     age 35
+    joined_on Ecto.Date.from_erl({1990, 5, 4})
   end
 end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -22,7 +22,7 @@ defmodule EctoFixtures.ParserTest do
         repo: Base,
         rows: %{
           brian: %{
-            data: %{name: "Brian", age: 35, joined_on: %Ecto.Date{year: 1990, month: 5, day: 5}}
+            data: %{name: "Brian", age: 35, joined_on: %Ecto.Date{year: 1990, month: 5, day: 4}}
           }
         }
       }

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -20,7 +20,11 @@ defmodule EctoFixtures.ParserTest do
       owners: %{
         model: Owner,
         repo: Base,
-        rows: %{brian: %{data: %{name: "Brian", age: 35}}}
+        rows: %{
+          brian: %{
+            data: %{name: "Brian", age: 35, joined_on: %Ecto.Date{year: 1990, month: 5, day: 5}}
+          }
+        }
       }
     }}
   end

--- a/test/support/migrations.exs
+++ b/test/support/migrations.exs
@@ -5,6 +5,7 @@ defmodule EctoFixtures.Migrations do
     create table(:owners) do
       add :name, :string
       add :age, :integer
+      add :joined_on, :date
     end
 
     create table(:cars, primary_key: false) do

--- a/test/support/models.exs
+++ b/test/support/models.exs
@@ -15,6 +15,7 @@ defmodule Owner do
   schema "owners" do
     field :name
     field :age, :integer
+    field :joined_on, Ecto.Date
 
     has_one :pet, Pet
     has_many :cars, Car


### PR DESCRIPTION
When using Elixir 1.2 and using code in the fixture definition (e.g. `Ecto.Date.from_erl({1990, 5, 4})`) it blows up because it returns the quoted AST.

I've added a failing test case and a partial fix. The fix I implemented fixed the parser, but breaks other tests. I'm not exactly sure where the failure is coming from. If you have any ideas I'd be happy to try them out and add an additional commit that fixes this.
