### PR TITLE
Upgrade Ecto

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: elixir
 elixir:
-  - 1.3.0
+  - 1.5.1
 otp_release:
   - 18.0
 sudo: false # to use faster container based build environment

--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule EctoFixtures.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:ecto, "~> 2.0.0"},
+      {:ecto, "~> 2.2.0"},
       {:postgrex, "> 0.0.0", only: :test},
       {:uuid, "~> 1.0"}
     ]

--- a/test/support/schemas.exs
+++ b/test/support/schemas.exs
@@ -163,6 +163,6 @@ defmodule Order do
   use Ecto.Schema
 
   schema "orders" do
-    field :cost
+    field :cost, :integer
   end
 end


### PR DESCRIPTION
This PR Upgrades Ecto to a more recent version, allowing compatibility with an incoming [DockYard API PR](https://github.com/DockYard/dockyard-api/pull/232). Merging this PR into master would allow the previously mentioned PR to use this library without directly referencing the branch in in its dependency declaration. To accomplish this, a few `mix.exs` lines were updated, a forgotten field declaration had to be added, and the TravisCI Elixir version had to be updated to `1.5.1`. This PR is currently a blocker for https://github.com/DockYard/dockyard-api/pull/232.