### PR TITLE
Fix warnings in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,9 +6,9 @@ defmodule EctoFixtures.Mixfile do
      version: "0.0.2",
      elixir: "~> 1.2",
      name: "Ecto Fixtures",
-     deps: deps,
-     package: package,
-     description: description]
+     deps: deps(),
+     package: package(),
+     description: description()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
```
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  ecto_fixtures/mix.exs:9

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  ecto_fixtures/mix.exs:10

warning: variable "description" does not exist and is being expanded to "description()", please use parentheses to remove the ambiguity or change the variable name
  ecto_fixtures/mix.exs:11
```