### PR TITLE
switch `uuid` dependency to `elixir_uuid`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ accounts model: Account, repo: Repo do
   test do
     email "test@example.com"
     name "Brian Cardarella"
-    password_hash :crypto.sha("password")
+    password_hash :crypto.hash(:sha, "password")
   end
 end
 ```
 
 In your test file you can access the fixture sets with the
-by tagging each test with the fixtures you want to load then 
+by tagging each test with the fixtures you want to load then
 pattern matching on the `data` field for the `context` argument.
 
 ```elixir
@@ -184,7 +184,7 @@ end
 ecto_fixtures will determine the assocation type being made and ensure
 that child records are always inserted *after* the parent record to
 avoid any foreign key constraint issues, regardless of the order in
-which the fixtures are loaded. 
+which the fixtures are loaded.
 
 ## Inheriting Data
 

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule EctoFixtures.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger, :uuid, :ecto]]
+    [applications: [:logger, :elixir_uuid, :ecto]]
   end
 
   def description do
@@ -44,7 +44,7 @@ defmodule EctoFixtures.Mixfile do
     [
       {:ecto, "> 0.0.0"},
       {:postgrex, "> 0.0.0", only: :test},
-      {:uuid, "~> 1.0"}
+      {:elixir_uuid, "~> 1.2"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,8 @@
-%{"connection": {:hex, :connection, "1.0.2"},
-  "decimal": {:hex, :decimal, "1.1.1"},
-  "ecto": {:hex, :ecto, "1.1.1"},
-  "poolboy": {:hex, :poolboy, "1.5.1"},
-  "postgrex": {:hex, :postgrex, "0.10.0"},
-  "uuid": {:hex, :uuid, "1.0.1"}}
+%{
+  "connection": {:hex, :connection, "1.0.2", "f4a06dd3ecae4141aa66f94ce92ea4c4b8753069472814932f1cadbc3078ab80", [:mix], [], "hexpm"},
+  "decimal": {:hex, :decimal, "1.1.1", "a8ff5b673105e6cdaca96f799aeefc6f07142881b616c65db16e14e556b16e76", [:mix], [], "hexpm"},
+  "ecto": {:hex, :ecto, "1.1.1", "9432c1f7da8d91ffb7ee1ac7f8a7b55c893a227553e5ed7f4d59e0423d48e551", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.5", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 1.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.4", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.10", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 0.7", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
+  "elixir_uuid": {:hex, :elixir_uuid, "1.2.0", "ff26e938f95830b1db152cb6e594d711c10c02c6391236900ddd070a6b01271d", [:mix], [], "hexpm"},
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
+  "postgrex": {:hex, :postgrex, "0.10.0", "98cf581bbb921d696db261d1a9e1740252714dbea1f9224d3291d58f2d88ea82", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm"},
+}

--- a/test/fixtures/function_call.exs
+++ b/test/fixtures/function_call.exs
@@ -1,5 +1,5 @@
 owners model: Owner, repo: BaseRepo do
   brian do
-    password_hash :crypto.sha("password")
+    password_hash :crypto.hash(:sha, "password")
   end
 end


### PR DESCRIPTION
The name of the package changed which causes errors in projects that depend on this library:

```
could not find an app file at "_build/test/lib/uuid/ebin/uuid.app"
```

**Also:**

fix incorrect `:crypto.sha` call

Use `:crypto.hash(:sha, “string”)` instead of `:crypto.sha(“string”)`

Fixes the following error:

```
  1) test can evaluate functions to generate values (EctoFixtures.Conditioners.FunctionCallTest)
     test/conditioners/function_call_test.exs:4
     ** (UndefinedFunctionError) function :crypto.sha/1 is undefined or private
     code: |> EctoFixtures.condition
     stacktrace:
       (crypto) :crypto.sha("password")
       (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
       (elixir) src/elixir.erl:233: :elixir.eval_forms/4
       (elixir) lib/code.ex:493: Code.eval_quoted/3
       (ecto_fixtures) lib/ecto/fixtures/conditioners/function_call.ex:8: anonymous fn/3 in EctoFixtures.Conditioners.FunctionCall.process/2
       (stdlib) lists.erl:1263: :lists.foldl/3
       test/conditioners/function_call_test.exs:8: (test)
```